### PR TITLE
fix: caps for samples labels and annotation types in input fields

### DIFF
--- a/app/models/sample_annotation.py
+++ b/app/models/sample_annotation.py
@@ -43,12 +43,20 @@ class SampleAnnotationUnit(CustomBaseModel):  # tpm row not sample annotation
     sample_label: str
     tpm: float
 
+    @validator("annotation_label", "sample_label", pre=True)
+    def upcase_type(cls, v):
+        return v.upper()
+
 
 class SampleAnnotationInput(CustomBaseModel):
     species_taxid: int
     gene_label: str  # Main Gene Identifier used for this db
     annotation_type: str  # Eg, Mapman annotations, GO, etc
     samples: list[SampleAnnotationUnit]
+
+    @validator("gene_label", "annotation_type", pre=True)
+    def upcase_type(cls, v):
+        return v.upper()
 
 
 class SampleAnnotationOut(SampleAnnotationBase):


### PR DESCRIPTION
Nested documents in sample annotation docs do not have sample labels and annotation label capitalized on Pydantic validation. Added that in the Pydantic model to ensure labels are consistently capitalized across.